### PR TITLE
From elastic search 7.4  org.elasticsearch.index.analysis.AbstractTok…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<version>9</version>
 	</parent>
 	<properties>
-		<elasticsearch.version>7.2.1</elasticsearch.version>
+		<elasticsearch.version>7.4.2</elasticsearch.version>
 		<elasticsearch.plugin.classname>org.codelibs.elasticsearch.kuromoji.ipadic.neologd.KuromojiNeologdPlugin</elasticsearch.plugin.classname>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/org/codelibs/elasticsearch/kuromoji/ipadic/neologd/index/analysis/KuromojiTokenizerFactory.java
+++ b/src/main/java/org/codelibs/elasticsearch/kuromoji/ipadic/neologd/index/analysis/KuromojiTokenizerFactory.java
@@ -47,7 +47,7 @@ public class KuromojiTokenizerFactory extends AbstractTokenizerFactory {
     private boolean discartPunctuation;
 
     public KuromojiTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         mode = getMode(settings);
         userDictionary = getUserDictionary(env, settings);
         discartPunctuation = settings.getAsBoolean("discard_punctuation", true);


### PR DESCRIPTION

From elastic search 7.4  org.elasticsearch.index.analysis.AbstractTokenizerFactory class has been change from (IndexSettings indexSettings, Settings settings) to (IndexSettings indexSettings, Settings settings, String name)

**7.3**
https://github.com/elastic/elasticsearch/blob/7.3/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java

**7.4**
https://github.com/elastic/elasticsearch/blob/7.4/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java

![fix_img](https://user-images.githubusercontent.com/32890718/118070599-313c9700-b3e1-11eb-9b8a-43de334759c0.png)

could you please update the source